### PR TITLE
Feat/inhumaciones payment status

### DIFF
--- a/src/inhumaciones/dto/create-inhumaciones.dto.ts
+++ b/src/inhumaciones/dto/create-inhumaciones.dto.ts
@@ -83,6 +83,16 @@ export class CreateInhumacionDto {
   @IsNotEmpty()
   codigo_inhumacion: string;
 
+  @ApiPropertyOptional({
+    description: 'Estado de pago de la inhumación',
+    enum: ['pending', 'paid'],
+    example: 'pending',
+    default: 'pending',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  paymentStatus?: 'pending' | 'paid';
 
   @IsString()
   @IsNotEmpty()

--- a/src/inhumaciones/dto/create-inhumaciones.dto.ts
+++ b/src/inhumaciones/dto/create-inhumaciones.dto.ts
@@ -1,4 +1,4 @@
-import { IsDate, IsNotEmpty, IsString, IsOptional, IsUUID, ValidateNested, IsObject } from 'class-validator';
+import { IsDate, IsNotEmpty, IsString, IsOptional, IsUUID, ValidateNested, IsObject, IsEnum } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { Nicho } from 'src/nicho/entities/nicho.entity';
@@ -91,7 +91,9 @@ export class CreateInhumacionDto {
     required: false,
   })
   @IsOptional()
-  @IsString()
+  @IsEnum(['pending', 'paid'], {
+    message: 'El estado de pago debe ser "pending" o "paid"',
+  })
   paymentStatus?: 'pending' | 'paid';
 
   @IsString()

--- a/src/inhumaciones/dto/update-inhumacione.dto.ts
+++ b/src/inhumaciones/dto/update-inhumacione.dto.ts
@@ -1,11 +1,13 @@
 import { IsNotEmpty, IsString, IsOptional } from 'class-validator';
 import { CreateInhumacionDto } from './create-inhumaciones.dto';
-import { PartialType } from '@nestjs/swagger';
+import { PartialType, OmitType } from '@nestjs/swagger';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ApiExtraModels } from '@nestjs/swagger';
 
 @ApiExtraModels(CreateInhumacionDto)
-export class UpdateInhumacionDto extends PartialType(CreateInhumacionDto) {
+export class UpdateInhumacionDto extends PartialType(
+  OmitType(CreateInhumacionDto, ['paymentStatus'] as const)
+) {
   @ApiProperty({
     description: 'ID único de la inhumación a actualizar',
     example: '123e4567-e89b-12d3-a456-426614174000',

--- a/src/inhumaciones/dto/update-payment-status.dto.ts
+++ b/src/inhumaciones/dto/update-payment-status.dto.ts
@@ -1,0 +1,16 @@
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdatePaymentStatusDto {
+  @ApiProperty({
+    description: 'Nuevo estado de pago de la inhumación',
+    enum: ['pending', 'paid'],
+    example: 'paid',
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsEnum(['pending', 'paid'], {
+    message: 'El estado de pago debe ser "pending" o "paid"',
+  })
+  paymentStatus: 'pending' | 'paid';
+}

--- a/src/inhumaciones/entities/inhumacion.entity.ts
+++ b/src/inhumaciones/entities/inhumacion.entity.ts
@@ -51,6 +51,12 @@ export class Inhumacion {
   @Column()
   codigo_inhumacion: string;
 
+  @Column({
+    type: 'enum',
+    enum: ['pending', 'paid'],
+    default: 'pending',
+  })
+  paymentStatus: 'pending' | 'paid';
 
   @OneToOne(() => RequisitosInhumacion, (requisitos) => requisitos.inhumacion, { nullable: true })
   @JoinColumn({ name: 'id_requisitos_inhumacion' })

--- a/src/inhumaciones/inhumaciones.controller.ts
+++ b/src/inhumaciones/inhumaciones.controller.ts
@@ -12,6 +12,7 @@ import {
   UploadedFiles,
 } from '@nestjs/common';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
+import { UpdatePaymentStatusDto } from './dto/update-payment-status.dto';
 import { InhumacionesService } from './inhumaciones.service';
 import { Inhumacion } from './entities/inhumacion.entity';
 import { UpdateInhumacionDto } from './dto/update-inhumacione.dto';
@@ -165,6 +166,30 @@ export class InhumacionesController {
     @Body() updateDto: UpdateInhumacionDto,
   ) {
     return this.service.update(id, updateDto);
+  }
+
+  @Patch(':id/payment-status')
+  // @UseGuards(JwtAuthGuard, RolesGuard) // habilitar para restringir solo a personal financiero
+  @ApiOperation({
+    summary: 'Actualizar estado de pago de una inhumación',
+    description: 'Marca la inhumación como "pending" (pendiente) o "paid" (pagada). Se usa cuando el cliente regresa de la ventanilla financiera con la factura.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID de la inhumación',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiBody({ type: UpdatePaymentStatusDto })
+  @ApiOkResponse({
+    description: 'Estado de pago actualizado exitosamente',
+    type: Inhumacion,
+  })
+  @ApiNotFoundResponse({ description: 'Inhumación no encontrada' })
+  async updatePaymentStatus(
+    @Param('id') id: string,
+    @Body() body: UpdatePaymentStatusDto,
+  ) {
+    return this.service.updatePaymentStatus(id, body.paymentStatus);
   }
 
   @Delete(':id')

--- a/src/inhumaciones/inhumaciones.service.ts
+++ b/src/inhumaciones/inhumaciones.service.ts
@@ -319,6 +319,26 @@ export class InhumacionesService {
   }
 
   /**
+   * Actualiza el estado de pago de una inhumación (pending|paid)
+   */
+  async updatePaymentStatus(id: string, status: 'pending' | 'paid') {
+    try {
+      const inhumacion = await this.repo.findOne({ where: { id_inhumacion: id } });
+      if (!inhumacion) {
+        throw new NotFoundException(`Inhumación con ID ${id} no encontrada`);
+      }
+
+      inhumacion.paymentStatus = status;
+      return await this.repo.save(inhumacion);
+    } catch (error) {
+      if (error instanceof NotFoundException) throw error;
+      throw new InternalServerErrorException(
+        'Error al actualizar el estado de pago: ' + (error.message || error),
+      );
+    }
+  }
+
+  /**
    * Elimina una inhumación por su ID
    */
   async remove(id: string) {


### PR DESCRIPTION
Este PR agrega la funcionalidad de estado de pago (`paymentStatus`) al módulo de inhumaciones con dos estados posibles:
- `pending`: Pago pendiente (estado inicial por defecto)
- `paid`: Pago confirmado

### Flujo de trabajo implementado:

1. **Creación de inhumación** → Estado de pago: `pending`
2. **Generación de orden de pago** → Cliente recibe orden
3. **Cliente paga en ventanilla financiera** → Obtiene factura
4. **Cliente regresa con factura** → Personal actualiza estado a `paid`

## 🔧 Cambios realizados

### Entity
  - Agregado campo `paymentStatus` en `Inhumacion` entity
  - Tipo: `ENUM('pending', 'paid')`
  - Default: `'pending'`

### DTOs
  - Campo opcional `paymentStatus` en `CreateInhumacionDto`
  - Excluido `paymentStatus` de `UpdateInhumacionDto` (evita actualizaciones accidentales)
  - Creado `UpdatePaymentStatusDto` con validación enum

### Service
  - Método `updatePaymentStatus(id, status)` 
  - Valida existencia de inhumación
  - Actualiza estado de pago
  - Manejo de errores con excepciones apropiadas

### Controller
  - Nuevo endpoint: `PATCH /inhumaciones/:id/payment-status`
  - Acepta `UpdatePaymentStatusDto`
  - Documentado en Swagger


