### PR TITLE
Huecos-Nichos: Soporte de ampliaciones con PDF y observación; endpoints multipart y descarga de archivo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,0 @@
-JWT_SECRET= asdjlsdfnjksdf
-DB_TYPE= postgres
-DB_HOST= localhost
-DB_PORT= 5433
-DB_NAME= DB_Cementerio
-DB_USER= postgres
-DB_PASSWORD= *****
-DB_SCHEMA= cementerio
-PORT= 3000

--- a/src/huecos-nichos/dto/create-huecos-nicho.dto.ts
+++ b/src/huecos-nichos/dto/create-huecos-nicho.dto.ts
@@ -51,4 +51,16 @@ export class CreateHuecosNichoDto {
   })
   @IsOptional()
   num_hueco?: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Observación de la ampliación asociada a la creación del hueco (opcional)',
+    example: 'Se amplía por solicitud del propietario',
+    required: false,
+    maxLength: 500,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  observacion_ampliacion?: string;
 }

--- a/src/huecos-nichos/entities/huecos-nicho.entity.ts
+++ b/src/huecos-nichos/entities/huecos-nicho.entity.ts
@@ -43,7 +43,7 @@ export class HuecosNicho {
   )
   requisitos_inhumacion: RequisitosInhumacion[];
 
-  @Column({ type: 'text', name: 'ruta_archivo_ampliacion' })
+  @Column({ type: 'text', name: 'ruta_archivo_ampliacion', nullable: true })
   ruta_archivo_ampliacion: string;
 
   @Column({ type: 'varchar', length: 500, name: 'observacion_ampliacion', nullable: true })

--- a/src/huecos-nichos/entities/huecos-nicho.entity.ts
+++ b/src/huecos-nichos/entities/huecos-nicho.entity.ts
@@ -43,6 +43,12 @@ export class HuecosNicho {
   )
   requisitos_inhumacion: RequisitosInhumacion[];
 
+  @Column({ type: 'text', name: 'ruta_archivo_ampliacion' })
+  ruta_archivo_ampliacion: string;
+
+  @Column({ type: 'varchar', length: 500, name: 'observacion_ampliacion', nullable: true })
+  observacion_ampliacion?: string;
+
   @CreateDateColumn({ type: 'date' })
   fecha_creacion: Date;
 

--- a/src/huecos-nichos/huecos-nichos.service.ts
+++ b/src/huecos-nichos/huecos-nichos.service.ts
@@ -321,4 +321,24 @@ export class HuecosNichosService {
       );
     }
   }
+
+  /**
+   * Obtiene la ruta del archivo PDF de ampliación para un hueco
+   */
+  async obtenerRutaArchivo(id: string): Promise<string | null> {
+    try {
+      const hueco = await this.huecoRepository.findOne({
+        where: { id_detalle_hueco: id },
+        select: ['id_detalle_hueco', 'ruta_archivo_ampliacion'],
+      });
+      if (!hueco || !hueco.ruta_archivo_ampliacion) {
+        return null;
+      }
+      return hueco.ruta_archivo_ampliacion;
+    } catch (error) {
+      throw new InternalServerErrorException(
+        'Error al obtener la ruta del archivo: ' + (error.message || error),
+      );
+    }
+  }
 }

--- a/src/huecos-nichos/huecos-nichos.service.ts
+++ b/src/huecos-nichos/huecos-nichos.service.ts
@@ -23,7 +23,7 @@ export class HuecosNichosService {
     createHuecosNichoDto: CreateHuecosNichoDto,
     file?: Express.Multer.File,
   ) {
-    console.log('Crear hueco DTO:', createHuecosNichoDto);
+    //console.log('Crear hueco DTO:', createHuecosNichoDto);
     try {
       if (!file) {
         throw new BadRequestException(

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,6 @@ async function bootstrap() {
     .build();
   const documentFactory = () => SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, documentFactory);
-  await app.listen(process.env.PORT ?? 3000);
+  await app.listen(process.env.PORT ?? 3005);
 }
 bootstrap();


### PR DESCRIPTION

Cambios
- Entidad `HuecosNicho`:
  - Añadidas columnas `ruta_archivo_ampliacion` (text, nullable) y `observacion_ampliacion` (varchar(500), nullable).
- DTOs:
  - `CreateHuecosNichoDto`: nuevo campo `observacion_ampliacion?`.
  - `UpdateHuecosNichoDto`: soporta `observacion_ampliacion?`.
- Controlador:
  - `POST /huecos-nichos`: ahora `multipart/form-data` con `FileInterceptor('file')` (PDF obligatorio). Documentación Swagger actualizada.
  - `PATCH /huecos-nichos/:id`: `multipart/form-data` con `file` opcional para reemplazo. Documentación Swagger actualizada.
  - `GET /huecos-nichos/:id/archivo`: endpoint para descargar el PDF.
- Servicio:
  - `create(...)`: guarda PDF en `uploads/ampliaciones/...`, persiste ruta y observación, valida tipo y presencia.
  - `update(...)`: reemplaza PDF si se envía; elimina archivo anterior de forma segura; actualiza observación.
  - `obtenerRutaArchivo(...)`: expone la ruta relativa para el controlador.
