### PR TITLE
feat: implement block type differentiation (Bloque vs Mausoleo)

### DIFF
--- a/src/bloques/README.md
+++ b/src/bloques/README.md
@@ -1,12 +1,14 @@
 # Módulo de Bloques
 
-Este módulo gestiona los bloques dentro de los cementerios. Cada bloque pertenece a un cementerio y contiene nichos organizados en filas y columnas que se crean automáticamente.
+Este módulo gestiona los bloques dentro de los cementerios. Cada bloque pertenece a un cementerio y contiene nichos organizados en filas y columnas que se crean automáticamente con comportamiento diferenciado según el tipo de bloque.
 
 ## Características
 
 - **CRUD completo**: Crear, leer, actualizar y eliminar bloques
+- **Dos tipos de bloques**: "Bloque" (estándar) y "Mausoleo" (personalizable)
 - **Creación automática de nichos**: Al crear un bloque, se generan automáticamente todos los nichos según las dimensiones (filas × columnas)
-- **Nichos con estado inicial "Deshabilitado"**: Los nichos creados automáticamente requieren habilitación posterior
+- **Bloques tipo "Bloque"**: Nichos habilitados automáticamente con 1 hueco disponible cada uno
+- **Bloques tipo "Mausoleo"**: Nichos deshabilitados que requieren habilitación manual
 - **Relación con cementerios**: Cada bloque pertenece a un cementerio específico
 - **Enumeración automática**: Los bloques se numeran automáticamente según el orden de creación en el cementerio
 - **Validaciones**: Nombres únicos por cementerio, valores mínimos para filas y columnas
@@ -24,12 +26,30 @@ Este módulo gestiona los bloques dentro de los cementerios. Cada bloque pertene
   numero: number;             // Número de bloque (asignado automáticamente)
   numero_filas: number;       // Cantidad de filas
   numero_columnas: number;    // Cantidad de columnas
+  tipo_bloque: string;        // Tipo: "Bloque" (default) o "Mausoleo"
   estado: string;             // Estado (Activo/Inactivo)
   fecha_creacion: string;     // Fecha de creación
   fecha_modificacion?: string; // Fecha de última modificación
   nichos: Nicho[];           // Relación con nichos
 }
 ```
+
+## Tipos de Bloque
+
+### **Bloque** (Por defecto)
+Bloques estándar con nichos listos para vender inmediatamente.
+- Nichos creados en estado `DISPONIBLE`
+- Cada nicho tiene 1 hueco automáticamente
+- Tipo de nicho: "Nicho Simple"
+- `fecha_adquisicion` establecida automáticamente
+- ✅ Listos para reservar y vender
+
+### **Mausoleo**
+Estructuras personalizables que requieren configuración manual.
+- Nichos creados en estado `DESHABILITADO`
+- Sin huecos iniciales
+- Tipo de nicho: null (configurar al habilitar)
+- ⚙️ Requieren habilitación antes de vender
 
 ## Flujo de Creación de Bloque
 
@@ -38,33 +58,54 @@ Cuando se crea un bloque:
 1. Se valida que el cementerio exista
 2. Se verifica que no exista un bloque activo con el mismo nombre en el cementerio
 3. Se asigna automáticamente el siguiente número disponible
-4. **Se crean automáticamente todos los nichos** (filas × columnas)
-5. Los nichos se crean con estado `Deshabilitado` y requieren habilitación posterior
+4. Se define el `tipo_bloque` ("Bloque" por defecto o "Mausoleo")
+5. **Se crean automáticamente todos los nichos** (filas × columnas)
+6. Según el tipo:
+   - **Bloque**: Nichos `DISPONIBLES` con 1 hueco cada uno
+   - **Mausoleo**: Nichos `DESHABILITADOS` sin huecos
 
-### Ejemplo: Bloque 2×3
+### Ejemplo: Bloque 2×3 tipo "Bloque"
 
-Al crear un bloque de 2 filas × 3 columnas, se crean automáticamente 6 nichos:
+Al crear un bloque de 2 filas × 3 columnas tipo "Bloque":
 
 ```
-Fila 1: [Nicho(1,1), Nicho(1,2), Nicho(1,3)]
-Fila 2: [Nicho(2,1), Nicho(2,2), Nicho(2,3)]
+Fila 1: [Nicho(1,1) ✅, Nicho(1,2) ✅, Nicho(1,3) ✅]
+Fila 2: [Nicho(2,1) ✅, Nicho(2,2) ✅, Nicho(2,3) ✅]
+
+Estado: DISPONIBLE
+Tipo: "Nicho Simple"
+Huecos: 1 por nicho (estado "Disponible")
+✅ Listos para vender
 ```
 
-Todos con estado inicial: `estadoVenta: "Deshabilitado"`
+### Ejemplo: Bloque 2×3 tipo "Mausoleo"
+
+Al crear un bloque de 2 filas × 3 columnas tipo "Mausoleo":
+
+```
+Fila 1: [Nicho(1,1) ⚠️, Nicho(1,2) ⚠️, Nicho(1,3) ⚠️]
+Fila 2: [Nicho(2,1) ⚠️, Nicho(2,2) ⚠️, Nicho(2,3) ⚠️]
+
+Estado: DESHABILITADO
+Tipo: null
+Huecos: ninguno
+⚠️ Requieren habilitación
+```
 
 ## Endpoints
 
 ### POST /bloques
 Crear un nuevo bloque con nichos automáticos
 
-**Request:**
+**Request (Tipo "Bloque" - por defecto):**
 ```json
 {
   "id_cementerio": "uuid-del-cementerio",
   "nombre": "Bloque A",
   "descripcion": "Bloque principal",
   "numero_filas": 10,
-  "numero_columnas": 15
+  "numero_columnas": 15,
+  "tipo_bloque": "Bloque"  // Opcional, por defecto "Bloque"
 }
 ```
 
@@ -77,12 +118,46 @@ Crear un nuevo bloque con nichos automáticos
     "numero": 1,
     "numero_filas": 10,
     "numero_columnas": 15,
+    "tipo_bloque": "Bloque",
     "descripcion": "Bloque principal",
     "estado": "Activo",
     "fecha_creacion": "2024-01-15T10:00:00Z"
   },
   "nichos_creados": 150,
-  "mensaje": "Bloque creado con 150 nichos deshabilitados"
+  "huecos_creados": 150,
+  "mensaje": "Bloque tipo 'Bloque' creado con 150 nichos habilitados (1 hueco cada uno)"
+}
+```
+
+**Request (Tipo "Mausoleo"):**
+```json
+{
+  "id_cementerio": "uuid-del-cementerio",
+  "nombre": "Mausoleo Familiar",
+  "descripcion": "Estructura familiar",
+  "numero_filas": 2,
+  "numero_columnas": 3,
+  "tipo_bloque": "Mausoleo"
+}
+```
+
+**Response:**
+```json
+{
+  "bloque": {
+    "id_bloque": "uuid",
+    "nombre": "Mausoleo Familiar",
+    "numero": 2,
+    "numero_filas": 2,
+    "numero_columnas": 3,
+    "tipo_bloque": "Mausoleo",
+    "descripcion": "Estructura familiar",
+    "estado": "Activo",
+    "fecha_creacion": "2024-01-15T10:00:00Z"
+  },
+  "nichos_creados": 6,
+  "huecos_creados": 0,
+  "mensaje": "Bloque tipo 'Mausoleo' creado con 6 nichos deshabilitados"
 }
 ```
 
@@ -141,7 +216,11 @@ Eliminar un bloque (soft delete - cambia estado a "Inactivo")
 
 ## Habilitación de Nichos
 
-Los nichos creados automáticamente están en estado "Deshabilitado". Para habilitarlos, use el endpoint de nichos:
+**Solo para bloques tipo "Mausoleo":** Los nichos deshabilitados requieren habilitación manual antes de poder venderlos.
+
+**Para bloques tipo "Bloque":** Los nichos ya están habilitados automáticamente y listos para vender.
+
+Para habilitar un nicho de mausoleo, use el endpoint:
 
 ### POST /nichos/:id/habilitar
 

--- a/src/bloques/bloques.module.ts
+++ b/src/bloques/bloques.module.ts
@@ -5,9 +5,10 @@ import { BloquesController } from './bloques.controller';
 import { Bloque } from './entities/bloque.entity';
 import { Cementerio } from 'src/cementerio/entities/cementerio.entity';
 import { Nicho } from 'src/nicho/entities/nicho.entity';
+import { HuecosNicho } from 'src/huecos-nichos/entities/huecos-nicho.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Bloque, Cementerio, Nicho])],
+  imports: [TypeOrmModule.forFeature([Bloque, Cementerio, Nicho, HuecosNicho])],
   controllers: [BloquesController],
   providers: [BloquesService],
   exports: [BloquesService, TypeOrmModule],

--- a/src/bloques/bloques.service.ts
+++ b/src/bloques/bloques.service.ts
@@ -10,6 +10,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Bloque } from './entities/bloque.entity';
 import { Cementerio } from 'src/cementerio/entities/cementerio.entity';
 import { Nicho } from 'src/nicho/entities/nicho.entity';
+import { HuecosNicho } from 'src/huecos-nichos/entities/huecos-nicho.entity';
 import { Like, Repository, Not } from 'typeorm';
 import { EstadoNicho } from 'src/nicho/enum/estadoNicho.enum';
 
@@ -22,6 +23,8 @@ export class BloquesService {
     private readonly cementerioRepository: Repository<Cementerio>,
     @InjectRepository(Nicho)
     private readonly nichoRepository: Repository<Nicho>,
+    @InjectRepository(HuecosNicho)
+    private readonly huecosNichoRepository: Repository<HuecosNicho>,
   ) {
     console.log('BloquesService initialized');
   }
@@ -81,6 +84,7 @@ export class BloquesService {
       bloque.numero = siguienteNumero; // Asignar número automáticamente
       bloque.numero_filas = createBloqueDto.numero_filas;
       bloque.numero_columnas = createBloqueDto.numero_columnas;
+      bloque.tipo_bloque = createBloqueDto.tipo_bloque || 'Bloque'; // Por defecto 'Bloque'
       // asignar la entidad Cementerio como relación
       bloque.cementerio = cementerio as any;
       try {
@@ -114,18 +118,24 @@ export class BloquesService {
       const savedBloque = await this.bloqueRepository.save(bloque);
 
       // Crear nichos automáticamente según filas y columnas
-      // Los nichos se crean SIN tipo ni num_huecos (se asignan al habilitar)
       const nichos: Nicho[] = [];
+      const esTipoBloque = savedBloque.tipo_bloque === 'Bloque';
+      
       for (let fila = 1; fila <= savedBloque.numero_filas; fila++) {
         for (let columna = 1; columna <= savedBloque.numero_columnas; columna++) {
+          const fechaCreacion = new Date().toISOString();
           const nicho = this.nichoRepository.create({
             id_bloque: savedBloque as any,
             id_cementerio: cementerio as any,
             fila: fila,
             columna: columna,
             estado: 'Activo',
-            estadoVenta: EstadoNicho.DESHABILITADO,
-            // tipo y num_huecos se asignan al habilitar el nicho
+            // Si es tipo Bloque: habilitar con 1 hueco, si es Mausoleo: deshabilitar
+            estadoVenta: esTipoBloque ? EstadoNicho.DISPONIBLE : EstadoNicho.DESHABILITADO,
+            num_huecos: esTipoBloque ? 1 : null,
+            tipo: esTipoBloque ? 'Nicho Simple' : null,
+            fecha_construccion: esTipoBloque ? fechaCreacion : null,
+            fecha_adquisicion: esTipoBloque ? fechaCreacion : null,
           });
           nichos.push(nicho);
         }
@@ -133,10 +143,31 @@ export class BloquesService {
 
       const nichosCreados = await this.nichoRepository.save(nichos);
 
+      // Si es tipo Bloque, crear los huecos automáticamente
+      let huecosCreados = 0;
+      if (esTipoBloque) {
+        const huecos: HuecosNicho[] = [];
+        for (const nicho of nichosCreados) {
+          const hueco = this.huecosNichoRepository.create({
+            id_nicho: nicho,
+            num_hueco: 1,
+            estado: 'Disponible',
+          });
+          huecos.push(hueco);
+        }
+        const savedHuecos = await this.huecosNichoRepository.save(huecos);
+        huecosCreados = savedHuecos.length;
+      }
+
+      const mensajeTipo = esTipoBloque 
+        ? `Bloque tipo 'Bloque' creado con ${nichosCreados.length} nichos habilitados (1 hueco cada uno)`
+        : `Bloque tipo 'Mausoleo' creado con ${nichosCreados.length} nichos deshabilitados`;
+
       return { 
         bloque: savedBloque,
         nichos_creados: nichosCreados.length,
-        mensaje: `Bloque creado con ${nichosCreados.length} nichos deshabilitados`
+        huecos_creados: huecosCreados,
+        mensaje: mensajeTipo
       };
     } catch (error) {
       if (error instanceof NotFoundException || error instanceof BadRequestException) {

--- a/src/bloques/bloques.service.ts
+++ b/src/bloques/bloques.service.ts
@@ -124,19 +124,22 @@ export class BloquesService {
       for (let fila = 1; fila <= savedBloque.numero_filas; fila++) {
         for (let columna = 1; columna <= savedBloque.numero_columnas; columna++) {
           const fechaCreacion = new Date().toISOString();
-          const nicho = this.nichoRepository.create({
-            id_bloque: savedBloque as any,
-            id_cementerio: cementerio as any,
-            fila: fila,
-            columna: columna,
-            estado: 'Activo',
-            // Si es tipo Bloque: habilitar con 1 hueco, si es Mausoleo: deshabilitar
-            estadoVenta: esTipoBloque ? EstadoNicho.DISPONIBLE : EstadoNicho.DESHABILITADO,
-            num_huecos: esTipoBloque ? 1 : null,
-            tipo: esTipoBloque ? 'Nicho Simple' : null,
-            fecha_construccion: esTipoBloque ? fechaCreacion : null,
-            fecha_adquisicion: esTipoBloque ? fechaCreacion : null,
-          });
+          const nicho = this.nichoRepository.create();
+          nicho.id_bloque = savedBloque as any;
+          nicho.id_cementerio = cementerio as any;
+          nicho.fila = fila;
+          nicho.columna = columna;
+          nicho.estado = 'Activo';
+          // Si es tipo Bloque: habilitar con 1 hueco, si es Mausoleo: deshabilitar
+          nicho.estadoVenta = esTipoBloque ? EstadoNicho.DISPONIBLE : EstadoNicho.DESHABILITADO;
+          
+          if (esTipoBloque) {
+            nicho.num_huecos = 1;
+            nicho.tipo = 'Nicho Simple';
+            nicho.fecha_construccion = fechaCreacion;
+            nicho.fecha_adquisicion = fechaCreacion;
+          }
+          
           nichos.push(nicho);
         }
       }

--- a/src/bloques/dto/create-bloque.dto.ts
+++ b/src/bloques/dto/create-bloque.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
+import { IsNotEmpty, IsString, IsInt, IsOptional, IsUUID, Min, IsIn } from 'class-validator';
 
 export class CreateBloqueDto {
   @IsNotEmpty()
@@ -22,4 +22,9 @@ export class CreateBloqueDto {
   @IsInt()
   @Min(1)
   numero_columnas: number;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['Bloque', 'Mausoleo'])
+  tipo_bloque?: string; // 'Bloque' (default) o 'Mausoleo'
 }

--- a/src/bloques/entities/bloque.entity.ts
+++ b/src/bloques/entities/bloque.entity.ts
@@ -25,6 +25,9 @@ export class Bloque {
   @Column({ type: 'varchar', length: 50, default: 'Activo' })
   estado: string;
 
+  @Column({ type: 'varchar', length: 50, default: 'Bloque' })
+  tipo_bloque: string; // 'Bloque' o 'Mausoleo'
+
   @Column({ type: 'varchar', length: 100, nullable: true })
   fecha_creacion?: string;
 

--- a/src/nicho/entities/nicho.entity.ts
+++ b/src/nicho/entities/nicho.entity.ts
@@ -68,8 +68,8 @@ export class Nicho {
   @Column({ type: 'varchar', name: 'fecha_construccion', nullable: true })
   fecha_construccion: string;
 
-  // @Column({ type: 'date', nullable: true })
-  // fecha_adquisicion?: Date
+  @Column({ type: 'varchar', nullable: true })
+  fecha_adquisicion?: string;
 
   @Column({ type: 'text', nullable: true })
   observaciones?: string;


### PR DESCRIPTION
Implementación de lógica diferenciada para la creación de nichos según el tipo de bloque.

Cambios principales:
- Nuevo campo 'tipo_bloque' en Bloque: valores 'Bloque' (por defecto) o 'Mausoleo'.
- Para bloques tipo 'Bloque': nichos creados como DISPONIBLE, con un hueco inicial, tipo 'Nicho Simple' y fecha_adquisicion igual a fecha_creacion.
- Para bloques tipo 'Mausoleo': nichos creados como DESHABILITADO, sin huecos iniciales, requieren habilitación manual.
- Nuevo campo opcional 'fecha_adquisicion' en la entidad Nicho.
- Actualizaciones en BloquesModule, BloquesService y creación automática de huecos en bloques estándar.
- Documentación actualizada en README de Nichos y Bloques.

Archivos modificados:
- src/bloques/entities/bloque.entity.ts
- src/bloques/dto/create-bloque.dto.ts
- src/bloques/bloques.service.ts
- src/bloques/bloques.module.ts
- src/nicho/entities/nicho.entity.ts
- src/nicho/README.md
- src/bloques/README.md

Testing:
- Compilación y servidor funcionando sin errores.
- Validaciones funcionando correctamente.

Casos de uso:
1) Crear bloque estándar: nichos disponibles con un hueco cada uno.
2) Crear mausoleo: nichos deshabilitados sin huecos iniciales.